### PR TITLE
chore(ci): Loosen iOS simulator OS version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build
-        run: xcodebuild build -scheme SdkMobileIOSNative -sdk "`xcrun --sdk iphonesimulator --show-sdk-path`" -destination "OS=18.4,name=iPhone 16"
+        run: xcodebuild build -scheme SdkMobileIOSNative -sdk "`xcrun --sdk iphonesimulator --show-sdk-path`" -destination "name=iPhone 16"
 
       - name: Run tests
-        run: xcodebuild test -scheme SdkMobileIOSNative -sdk "`xcrun --sdk iphonesimulator --show-sdk-path`" -destination "platform=iOS Simulator,OS=18.4,name=iPhone 16"
+        run: xcodebuild test -scheme SdkMobileIOSNative -sdk "`xcrun --sdk iphonesimulator --show-sdk-path`" -destination "platform=iOS Simulator,name=iPhone 16"


### PR DESCRIPTION
Seems like build image was updated and we no longer have access to 18.4. To avoid CI breaking in the future and let Actions update build images, OS version constraint was lifted.