### PR TITLE
chore(ci): Wait for simulators before build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch: 
 
 jobs:
   build:
@@ -13,8 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Wait for simulators
+        run: xcrun simctl list
       - name: Build
-        run: xcodebuild build -scheme SdkMobileIOSNative -sdk "`xcrun --sdk iphonesimulator --show-sdk-path`" -destination "name=iPhone 16"
+        run: xcodebuild build -scheme SdkMobileIOSNative -sdk "`xcrun --sdk iphonesimulator --show-sdk-path`" -destination "platform=iOS Simulator,arch=arm64,name=iPhone 16"
 
       - name: Run tests
-        run: xcodebuild test -scheme SdkMobileIOSNative -sdk "`xcrun --sdk iphonesimulator --show-sdk-path`" -destination "platform=iOS Simulator,name=iPhone 16"
+        run: xcodebuild test -scheme SdkMobileIOSNative -sdk "`xcrun --sdk iphonesimulator --show-sdk-path`" -destination "platform=iOS Simulator,arch=arm64,name=iPhone 16"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+    - name: Wait for simulators
+      run: xcrun simctl list  
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -61,10 +63,9 @@ jobs:
 
     #   If the Autobuild fails above, remove it and uncomment the following three lines.
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
     - run: |
         echo "Run, Build Application"
-        xcodebuild build -scheme SdkMobileIOSNative -sdk "`xcrun --sdk iphonesimulator --show-sdk-path`" -destination "OS=18.4,name=iPhone 16"
+        xcodebuild build -scheme SdkMobileIOSNative -sdk "`xcrun --sdk iphonesimulator --show-sdk-path`" -destination "platform=iOS Simulator,arch=arm64,name=iPhone 16"
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      
+      - name: Wait for simulators
+        run: xcrun simctl list      
 
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -28,5 +31,5 @@ jobs:
       - run: swiftlint lint .
 
       - run: swiftformat --lint .
-
+      
       - run: .github/workflows/unused-variables.sh

--- a/.github/workflows/unused-variables.sh
+++ b/.github/workflows/unused-variables.sh
@@ -3,7 +3,7 @@ derived_data_path=.build/DerivedData
 
 # Build the SDK package using xcodebuild.
 xcodebuild build -scheme SdkMobileIOSNative -sdk "`xcrun --sdk iphonesimulator --show-sdk-path`" \
--destination "OS=18.4,name=iPhone 16" -derivedDataPath ${derived_data_path} clean build
+-destination "platform=iOS Simulator,arch=arm64,name=iPhone 16" -derivedDataPath ${derived_data_path} clean build
 
 # Run Periphery to scan for unused variables.
 periphery scan --skip-build --index-store-path $derived_data_path/Index.noindex/DataStore


### PR DESCRIPTION
CI seemed to fail randomly. It is because simulators and thus build destinations might not be available at the point in time when build command is issued. With this workaround, we do wait for them to become available. 